### PR TITLE
Add functionality to stream dask arrays into ims

### DIFF
--- a/imarispy/imaris.py
+++ b/imarispy/imaris.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         os.remove(fn)
     array_to_ims(im, fn)
 
-    # dask array to ims
+    # create dask array
     import dask.array as da
     im_da = da.from_array(im)
 

--- a/imarispy/imaris.py
+++ b/imarispy/imaris.py
@@ -1,17 +1,28 @@
 import numpy as np
 import re
 import h5py
-from .util import h5str, make_thumbnail, subsample_data
+from util import h5str, make_thumbnail, subsample_data
 import logging
 logger = logging.getLogger(__name__)
 
 
-def np_to_ims(array, fname='myfile.ims',
+def array_to_ims(array, fname='myfile.ims',
               subsamp=((1, 1, 1), (1, 2, 2)),
               chunks=((16, 128, 128), (64, 64, 64)),
               compression='gzip',
               thumbsize=256,
               dx=0.1, dz=0.25):
+    """
+    :param array: Supports numpy and dask arrays
+    :param fname:
+    :param subsamp:
+    :param chunks:
+    :param compression:
+    :param thumbsize:
+    :param dx:
+    :param dz:
+    :return:
+    """
 
     assert len(subsamp) == len(chunks)
     assert all([len(i) == 3 for i in subsamp]), 'Only deal with 3D chunks'
@@ -93,6 +104,16 @@ def np_to_ims(array, fname='myfile.ims',
         for grp, (key, value) in ATTRS:
             hf[grp].attrs.create(key, h5str(value))
 
+        if type(array) == np.ndarray:
+            is_numpy = True
+        else:
+            import dask
+            if type(array) == dask.array.core.Array:
+                is_numpy = False
+                dset_map = dict()
+            else:
+                raise(Exception('array type not supported'))
+
         try:
             thumb = make_thumbnail(array[0], thumbsize)
             hf.create_dataset('Thumbnail/Data', data=thumb, dtype='u1')
@@ -107,18 +128,43 @@ def np_to_ims(array, fname='myfile.ims',
                 for r in range(nr):
                     if any([i > 1 for i in subsamp[r]]):
                         data = subsample_data(data, subsamp[r])
-                    hist, edges = np.histogram(data, 256)
+
                     grp = hf.create_group(fmt.format(r=r, t=t, c=c))
-                    print("Writing: %s" % grp)
+                    curr_chunks = tuple(min(*n) for n in zip(chunks[r], data.shape))
+                    if is_numpy:
+                        # if array is a np.array, write to file immediately
+                        print("Writing: %s" % grp)
+                        hist, edges = np.histogram(data, 256)
+                        grp.create_dataset('Data',
+                                           data=data,
+                                           chunks=curr_chunks,
+                                           compression=compression)
+                    else:
+                        # if array is da.array, only prepare hdf5 dsets
+                        # and write after dask optimized chunk calculation
+                        # for the different resolutions and use
+                        # dask.array.core.store to stream the data to disk.
+                        hist, edges = np.histogram(np.zeros(1), 256)
+                        dset = grp.require_dataset('Data',
+                                                   shape=data.shape,
+                                                   dtype=data.dtype,
+                                                   chunks=curr_chunks,
+                                                   compression=compression)
+                        dset_map[dset] = data
+
                     grp.create_dataset('Histogram', data=hist.astype(np.uint64))
                     grp.attrs.create('HistogramMin', h5str(edges[0]))
                     grp.attrs.create('HistogramMax', h5str(edges[-1]))
-                    grp.create_dataset('Data', data=data,
-                                       chunks=tuple(min(*n) for n in zip(chunks[r], data.shape)),
-                                       compression=compression)
                     grp.attrs.create('ImageSizeX', h5str(data.shape[2]))
                     grp.attrs.create('ImageSizeY', h5str(data.shape[1]))
                     grp.attrs.create('ImageSizeZ', h5str(data.shape[0]))
+
+        # stream dask array into file
+        if not is_numpy:
+            print("Writing dask array into %s" %fn)
+            dask.array.core.store(list(dset_map.values()),
+                                  list(dset_map.keys())
+                                  )
 
     return fname
 
@@ -128,3 +174,28 @@ def unmap_bdv_from_imaris(hf):
         if re.match(r'^t\d{5}$', i) or re.match(r'^s\d{2}$', i):
             del hf[i]
     return
+
+
+if __name__ == "__main__":
+
+    # Example usage
+
+    # create image
+    im = np.random.randint(0, 100, (20, 30, 40), dtype=np.uint16)
+
+    # numpy array to ims
+    import os
+    fn = '/tmp/myfile_np.ims'
+    if os.path.exists(fn):
+        os.remove(fn)
+    array_to_ims(im, fn)
+
+    # dask array to ims
+    import dask.array as da
+    im_da = da.from_array(im)
+
+    # dask array to ims
+    fn = '/tmp/myfile_da.ims'
+    if os.path.exists(fn):
+        os.remove(fn)
+    array_to_ims(im_da, fn)

--- a/imarispy/imaris.py
+++ b/imarispy/imaris.py
@@ -161,7 +161,7 @@ def np_to_ims(array, fname='myfile.ims',
 
         # stream dask array into file
         if not is_numpy:
-            print("Writing dask array into %s" %fn)
+            print("Writing dask array into %s" %fname)
             dask.array.core.store(list(dset_map.values()),
                                   list(dset_map.keys())
                                   )

--- a/imarispy/imaris.py
+++ b/imarispy/imaris.py
@@ -1,12 +1,12 @@
 import numpy as np
 import re
 import h5py
-from util import h5str, make_thumbnail, subsample_data
+from .util import h5str, make_thumbnail, subsample_data
 import logging
 logger = logging.getLogger(__name__)
 
 
-def array_to_ims(array, fname='myfile.ims',
+def np_to_ims(array, fname='myfile.ims',
               subsamp=((1, 1, 1), (1, 2, 2)),
               chunks=((16, 128, 128), (64, 64, 64)),
               compression='gzip',

--- a/imarispy/imaris.py
+++ b/imarispy/imaris.py
@@ -174,28 +174,3 @@ def unmap_bdv_from_imaris(hf):
         if re.match(r'^t\d{5}$', i) or re.match(r'^s\d{2}$', i):
             del hf[i]
     return
-
-
-if __name__ == "__main__":
-
-    # Example usage
-
-    # create image
-    im = np.random.randint(0, 100, (20, 30, 40), dtype=np.uint16)
-
-    # numpy array to ims
-    import os
-    fn = '/tmp/myfile_np.ims'
-    if os.path.exists(fn):
-        os.remove(fn)
-    array_to_ims(im, fn)
-
-    # create dask array
-    import dask.array as da
-    im_da = da.from_array(im)
-
-    # dask array to ims
-    fn = '/tmp/myfile_da.ims'
-    if os.path.exists(fn):
-        os.remove(fn)
-    array_to_ims(im_da, fn)


### PR DESCRIPTION
PR discussed in detail here: https://github.com/tlambert03/imarispy/issues/2

In summary: PR extends the functionality of `np_to_ims` to also handle dask arrays. As a result, dask array computations can directly be streamed to imaris files containing a pyramidal data structure for improved visualization performance.